### PR TITLE
new meta: translation version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * More mobile-friendly layout / font size handling (#19).
 * Added a `make clean` target to clean the `build/` directory (#22).
 * Added a `.htaccess` file to serve `.md` files with the utf-8 encoding (#23).
+* Indicate the translation version if mentioned in the `meta.yaml` file (#20).
 
 ## 1.0.1 (2016-05-03)
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,15 @@ The meta file is a [YAML](http://yaml.org/), but it shouldn't be a problem. Your
 ```yaml
 label: Klingon
 author: B'Elanna Torres
+version: '1.1.2'
 ```
 
 **Important**
 
+* All the field **names** are case-sensitive, so be careful if you're writing this file yourself.
 * The meta file is completely optional, but it'll help improve the look'n'feel of the homepage.
-* the words `label` and `author` are case sensitive, so they'll *have* to be written exactly like this.
-* the `author` information is optional, although I'd recommend to provide it, in order to receive feedback (including praises from the community).
+* None of the fields are required you can only specify one, two or all of them ; your choice.
+* even though the `author` information is optional, although I'd recommend to provide it, in order to receive feedback (including praises from the community).
 
 ----
 

--- a/build.py
+++ b/build.py
@@ -140,9 +140,11 @@ class Builder(object):
         for language in self.languages:
             label = language
             author = None
+            version = None
             if language in self.meta:
                 label = self.meta[language].get('label', label)
                 author = self.meta[language].get('author', None)
+                version = self.meta[language].get('version', None)
             item = '* [{label}]({language}/)'.format(
                 label=label,
                 language=language
@@ -151,6 +153,10 @@ class Builder(object):
             # Add optional author
             if author:
                 item = '{}, by {}'.format(item, author)
+
+            # Add optional version
+            if version:
+                item = '{} (v{})'.format(item, version)
 
             # Add link to source
             item = '{item} ([source]({language}/the-black-hack.md))'.format(

--- a/english/meta.yaml
+++ b/english/meta.yaml
@@ -1,2 +1,3 @@
 label: English
 author: David Black
+version: '1.2'

--- a/french/meta.yaml
+++ b/french/meta.yaml
@@ -1,2 +1,3 @@
 label: Français
 author: Bruno Bord
+version: '1.0'

--- a/spanish/meta.yaml
+++ b/spanish/meta.yaml
@@ -1,2 +1,3 @@
 label: Castellano
 author: Rafael Pardo Macías
+version: '0.3'


### PR DESCRIPTION
Each translation can have its own version, stored in the ``meta.yaml``.