### PR TITLE
Indicate the number of available languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master (unreleased)
+
+* Added a "language count" on the homepage (#43)
+
 ## 2.3.0 (2016-09-16)
 
 * Fix the Italian "Cockatrice" translation (#40).

--- a/index.md
+++ b/index.md
@@ -12,7 +12,10 @@ See the [License page](license.html) for more details.
 
 ## List of available texts
 
+"The Black Hack" core rules are currently available in $language_count languages (and soon, yours?):
+
 $text_list
+
 
 ## Contributing
 

--- a/toolbox/__init__.py
+++ b/toolbox/__init__.py
@@ -216,7 +216,10 @@ class Builder(object):
         homepage_md = self.get_template('index.md')
         text_list = self.build_homepage_text_list()
         # Build generated body using text_list
-        body_md = homepage_md.substitute(text_list='\n'.join(text_list))
+        body_md = homepage_md.substitute(
+            text_list='\n'.join(text_list),
+            language_count=len(self.languages),
+        )
         body_html = self.convert_md_source(body_md)
         # Build html page content
         self.write_html(

--- a/toolbox/__init__.py
+++ b/toolbox/__init__.py
@@ -23,7 +23,7 @@ DEFAULT_PAGE = {}
 class Builder(object):
 
     exceptions = (
-        'build', 'static', 'templates', 'tests',
+        'build', 'static', 'templates', 'tests', 'toolbox',
         # Warning: ignoring it to add it on the top position in the list
         'english',
     )


### PR DESCRIPTION
> This SRD is available in no less than ``$language_numbers``.