### PR TITLE
Spanish table headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Do not set a specific version for Python (#49).
 * Added correct page-breaks in every "The Black Hack" PDF generated (#45).
 * Added Korean translation, thx to *Siwook Oh* (#51).
+* Fixed ugly table headers in Spanish translation (#52).
 
 ## 2.3.1 (2016-10-10)
 

--- a/spanish/the-black-hack.md
+++ b/spanish/the-black-hack.md
@@ -167,7 +167,7 @@ Cuando un personaje es reducido a cero **Puntos de Golpe (PG)** están **Fuera d
 
 ***Si un personaje pierde el combate o sus compañeros son incapaces de recuperar su cuerpo ¡este es eliminado para siempre!***
 
-| 1d6 | RESULTADO                                                                                     |
+| *1d6* | *RESULTADO*                                                                                     |
 |:----|:----------------------------------------------------------------------------------------------|
 | 1   | **KO** – Sólo quedaste inconsciente                                                           |
 | 2   | **Aturdido** – Tienes Desventaja en todas las pruebas durante la siguiente hora.              |


### PR DESCRIPTION
table headers should not use numbers, because numbers are ugly with this font. See table after *Muerte*