### PR TITLE
Back to Python-Markdown 2.6.7, the 2.6.8 has added a regression with single column tables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added Korean translation, thx to *Siwook Oh* (@cynicaltalk) (#51 + fixes in #55 & #56).
 * Added Korean translation of "Additional Things" - Thx to @cynicaltalk (#54).
 * Fixed ugly table headers in Spanish translation (#52).
+* Fixed the single-column-table regression introduced by Python-Markdown 2.6.8 (#58).
 
 ## 2.3.1 (2016-10-10)
 

--- a/build-requirements.pip
+++ b/build-requirements.pip
@@ -3,3 +3,5 @@ PyYAML
 shell
 cached-property
 python-slugify
+# Temporary fix:
+Markdown==2.6.7


### PR DESCRIPTION
ref:

* #58
* https://github.com/waylan/Python-Markdown/issues/539
* https://github.com/waylan/Python-Markdown/pull/540